### PR TITLE
Update plotly.py

### DIFF
--- a/tethysapp/gizmo_showcase/controllers/plotly.py
+++ b/tethysapp/gizmo_showcase/controllers/plotly.py
@@ -86,7 +86,7 @@ def plotly_view(request):
         xaxis_tickfont_size=14,
         yaxis=dict(
             title='USD (millions)',
-            titlefont_size=16,
+            title_font_size=16,
             tickfont_size=14,
         ),
         legend=dict(


### PR DESCRIPTION
titlefont_size doesn't exist, instead replaced for title_font_size. See for more info: https://plotly.com/python/reference/layout/#layout-title-font-size